### PR TITLE
[WIP] feat: Changes in management of layer dependencies and metapackage names

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,4 +166,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/.layerapi2_dependencies
+++ b/.layerapi2_dependencies
@@ -1,0 +1,5 @@
+root@mfcom
+python3@mfcom
+scientific@mfext
+#+python3_circus@mfext
+#+rpm@mfext

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ MODULE_LOWERCASE=mfbase
 -include $(MFEXT_HOME)/share/main_root.mk
 
 all:: directories
-	echo "root@mfcom" >$(MFBASE_HOME)/.layerapi2_dependencies
-	echo "scientific@mfext" >>$(MFBASE_HOME)/.layerapi2_dependencies
 	cd adm && $(MAKE)
 	cd config && $(MAKE)
 	cd layers && $(MAKE)

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,0 +1,3 @@
+root@mfbase
+python@mfbase
+default@mfcom

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,0 +1,1 @@
+default@mfbase

--- a/layers/layer9_default/Makefile
+++ b/layers/layer9_default/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk

--- a/layers/layer9_python/.layerapi2_dependencies
+++ b/layers/layer9_python/.layerapi2_dependencies
@@ -1,0 +1,2 @@
+python@mfcom
+python3@mfbase

--- a/layers/layer9_python/.layerapi2_label
+++ b/layers/layer9_python/.layerapi2_label
@@ -1,0 +1,1 @@
+python@mfbase

--- a/layers/layer9_python/Makefile
+++ b/layers/layer9_python/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk


### PR DESCRIPTION
(only minimal and full)
Associated with changes in mfext _metwork.spec, this reduces the number of layers installed by default when installing mfbase (only necessary mfext layers are installed)
Metapackage metwork-mfbase-minimal only installs the necessary layers for mfbase to work properly
Metapackage metwork-mfbase or metwork-mfbase-full installs all mfbase layers

linked to #26 (mfbase part)